### PR TITLE
[fix] Add contact -- var name discrepancy

### DIFF
--- a/backend/src/webApp/webApp.py
+++ b/backend/src/webApp/webApp.py
@@ -252,7 +252,7 @@ class WebApp():
                 emailAddress: str,
                 password: str,
                 carrier: str,
-                phoneNum: str,
+                phoneNumber: str,
                 message: str,
                 task: str
             }
@@ -267,7 +267,7 @@ class WebApp():
             "emailAddress":     "",
             "password":         "",
             "carrier":          "",
-            "phoneNum":         "",
+            "phoneNumber":         "",
             "message":          "",
             "task":             ""
         }


### PR DESCRIPTION
- html form id is "phoneNumber", which means it could not be found