### PR TITLE
Fix/recv/filter

### DIFF
--- a/backend/src/constants.py
+++ b/backend/src/constants.py
@@ -13,6 +13,8 @@ class Constants():
 
         # EmailAgent / Databases
         self.contactListKey = "contact-list"
+        self.openUnread = '(BODY.PEEK[])'
+        self.openMarkRead = '(RFC822)'
 
         # Web App
         self.siteTitleDict = {

--- a/backend/src/database/databaseBaseClass.py
+++ b/backend/src/database/databaseBaseClass.py
@@ -26,15 +26,15 @@ class DatabaseBaseClass(Constants):
         self.usersColl = self.dbClient[self._userCollectionName] # this is for web app
         self.contactsColl = self.dbClient[self._contactsCollectionName] # this is for email agent to manage contact lists
 
-    def _createCollDNE(self, collObj:MongoClient):
+    def _createCollDNE(self, collObj:MongoClient, printCreation=True):
         """Wrapper of lowest level api functions that creates a collection if it does not exist (DNE)"""
         exists = self.__doesCollExist(collObj)
         collName = collObj.name
         if not exists:
-            print(f"Database collection '{collName}' does not exist... creating")
+            if printCreation: print(f"Database collection '{collName}' does not exist... creating")
             self._createCollection(collObj)
         else:
-            print(f"Database collection '{collName}' already exists")
+            if printCreation: print(f"Database collection '{collName}' already exists")
 
     def __doesCollExist(self, collObj:MongoClient)->bool():
         collectionNames = self.dbClient.list_collection_names()

--- a/backend/src/database/databaseBaseClass.py
+++ b/backend/src/database/databaseBaseClass.py
@@ -54,6 +54,12 @@ class DatabaseBaseClass(Constants):
         # else:               self.usersColl.insert_many(data)
 
     def _replaceDataById(self, collObj:MongoClient, userId:str, newData:dict):
+        """
+            \n@Brief: Updates the FIRST card within the collection fitting the filter with 'newData'
+            \n@Param: collObj - The collection object
+            \n@Param: userId - The UUID of the user's data to replace/update
+            \n@Param: newData - The data to update the card with
+        """
         query = {"id": userId}
         self._replaceData(collObj, query, newData)
 

--- a/backend/src/database/databaseManager.py
+++ b/backend/src/database/databaseManager.py
@@ -20,7 +20,7 @@ from backend.src.database.contactsCollectionManager import ContactsCollectionMan
 class DatabaseManager(UsersCollectionManager, ContactsCollectionManager):
     _numInits = 0
 
-    def __init__(self):
+    def __init__(self, printCollectionCreation=True):
         """
             \n@Brief: This class is meant to help manage the database of users' information
             \n@Note: Will create the database if it does not already exist
@@ -34,6 +34,6 @@ class DatabaseManager(UsersCollectionManager, ContactsCollectionManager):
             # if db or collection(s) don't exist, add dummy data to them to create it
             allCollections = [self.usersColl, self.contactsColl]
             for collObj in allCollections: 
-                self._createCollDNE(collObj)
+                self._createCollDNE(collObj, printCreation=printCollectionCreation)
         DatabaseManager._numInits += 1
 

--- a/backend/src/database/usersCollectionManager.py
+++ b/backend/src/database/usersCollectionManager.py
@@ -65,11 +65,7 @@ class UsersCollectionManager(DatabaseBaseClass):
             \n@Return: The 'User' object (None if 'User' DNE or unset)
         """
         userDoc = self._getDocById(self.usersColl, userToken)
-        if utils.keyExists(userDoc, "User") and userDoc["User"] != None:
-            serializedUserObj = userDoc["User"]
-            userObj = self._deserializeData(serializedUserObj)
-        else: userObj = None
-        return userObj
+        return self.__checkIfUserValid(userDoc)
 
     def getUserByUsername(self, username):
         """
@@ -77,8 +73,18 @@ class UsersCollectionManager(DatabaseBaseClass):
             \n@Returns: None if username does not exist
         """
         userDoc = self._getDocByUsername(self.usersColl, username)
-        serializedUserObj = userDoc["User"]
-        userObj = self._deserializeData(serializedUserObj)
+        return self.__checkIfUserValid(userDoc)
+
+    def __checkIfUserValid(self, userDoc:dict):
+        """
+            \n@Brief: Helper function that checks if the 'User' obj within the document has been set and is valid
+            \n@Param: userDoc - The dictionary containing the information belonging to a specific user
+            \n@Return: The User object 
+        """
+        if utils.keyExists(userDoc, "User") and userDoc["User"] != None:
+            serializedUserObj = userDoc["User"]
+            userObj = self._deserializeData(serializedUserObj)
+        else: userObj = None
         return userObj
 
     def getPasswordFromUsername(self, username:str)->str():

--- a/backend/src/database/usersCollectionManager.py
+++ b/backend/src/database/usersCollectionManager.py
@@ -37,7 +37,7 @@ class UsersCollectionManager(DatabaseBaseClass):
             "password": password,
             "User": self._serializeObj(userObj) if userObj != None else None # need to serialize object for storage
         }
-        self._insertData(self.usersColl, newUser)
+        self._replaceDataById(self.usersColl, userToken, newUser)
 
     def isUsernameInUse(self, usernameToTest:str):
         usernameExists = self._docExists(self.usersColl, {"username": usernameToTest})
@@ -93,10 +93,10 @@ class UsersCollectionManager(DatabaseBaseClass):
     def getPasswordFromId(self, myId:str)->str():
         """
             \n@Param: myId - The password to find's id
-            \n@Returns: The matching password 
+            \n@Returns: The matching password (or "" if not yet set)
         """
-        match = list(self.usersColl.find({"id": myId}))
-        actualPassword = match[0]["password"]
+        match = list(self.usersColl.find({"id": myId}))[0]
+        actualPassword = match["password"] if utils.keyExists(match, "password") else ""
         return actualPassword
 
     def updateUserObjById(self, myId:str, updatedUserObj:object)->dict():
@@ -123,6 +123,18 @@ class UsersCollectionManager(DatabaseBaseClass):
         """
         query = {"id": myId}
         toUpdateWith = {"$set": {"username": username}}
+        return self.usersColl.update_one(query, toUpdateWith)
+
+    def setPasswordById(self, myId:str, password:str):
+        """
+            \n@Brief: Sets the password in the database for the user with 'myId'
+            \n@Param: myId - The id of the user whose username you want to set
+            \n@Param: password - The password to set
+            \n@Note: Probably only useful for command line uses
+            \n@Returns: An instance of UpdateResult
+        """
+        query = {"id": myId}
+        toUpdateWith = {"$set": {"password": password}}
         return self.usersColl.update_one(query, toUpdateWith)
 
     def getUsernameById(self, myId:str)->str():

--- a/backend/src/database/usersCollectionManager.py
+++ b/backend/src/database/usersCollectionManager.py
@@ -59,21 +59,35 @@ class UsersCollectionManager(DatabaseBaseClass):
         matchId = match[0]["id"]
         return matchId
 
-    def findUserById(self, userToken):
+    def findUserById(self, userToken, UserObjRef):
         """
             \n@Param: userToken - The user's unique token id
+            \n@Param: UserObjRef - reference to the constructor for the User object
             \n@Return: The 'User' object (None if 'User' DNE or unset)
         """
         userDoc = self._getDocById(self.usersColl, userToken)
-        return self.__checkIfUserValid(userDoc)
+        return self._createUserIfDNE(userDoc, UserObjRef)
 
-    def getUserByUsername(self, username):
+    def getUserByUsername(self, username, UserObjRef):
         """
             \n@Param: username: The username of the user's account
+            \n@Param: UserObjRef - reference to the constructor for the User object
             \n@Returns: None if username does not exist
         """
         userDoc = self._getDocByUsername(self.usersColl, username)
-        return self.__checkIfUserValid(userDoc)
+        return self._createUserIfDNE(userDoc, UserObjRef)
+
+    def _createUserIfDNE(self, userDoc, UserObjRef):
+        """
+            \n@Brief: Get the User object referenced in the document. If it doesn't exist, create one
+            \n@Param: userDoc - The dictionary containing the information belonging to a specific user
+            \n@Param: UserObjRef - reference to the constructor for the User object
+            \n@Returns: The User object associated with the document (creates one if not already made/set)
+            \n@Note: Good if paired with '__checkIfUserValid'
+        """
+        userObj = self.__checkIfUserValid(userDoc)
+        userId = userDoc["id"]
+        return userObj if userObj != None else UserObjRef(userId)
 
     def __checkIfUserValid(self, userDoc:dict):
         """

--- a/backend/src/emailing/emailAgent.py
+++ b/backend/src/emailing/emailAgent.py
@@ -894,7 +894,7 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
             print("WARNING UNKNOWN EMAIL FILTER ENTERED- may result in undefined behavior")
 
         # opens folder/label you want to read from
-        self.IMAPClient.select('INBOX')
+        self.IMAPClient.select('INBOX', readonly=False)
         # print("Successfully Opened Inbox")
                     
         # get all the emails and their id #'s that match the filter
@@ -902,15 +902,9 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
         if rtnCode != "OK":
             print("Bad return code from inbox!")
 
-        numEmails = len(data[0].decode()) 
-        msgIds = data[0].decode() # convert byte to string
-
-        # convert to descending ordered list (msgIds is a str with the msgIds seperated by spaces)
-        idList = list(map(lambda x:int(x), list(msgIds.split()))) 
-        idList.sort(reverse = True) # sort() performs operation on the same variable
-        # print("idList: {0}".format(idList))
-        
-        return idList
+        msgIdsList = data[0].decode().split()
+        msgIdsList.reverse()
+        return msgIdsList
 
     def fetchEmail(self, emailIdNum:int, leaveUnread:bool=True)->bytearray():
         """
@@ -923,7 +917,7 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
         """
         if leaveUnread:     openCode = '(BODY.PEEK[])'
         else:               openCode = '(RFC822)'
-        rtnCode, emailData = self.IMAPClient.fetch(str(emailIdNum).encode(), openCode) 
+        rtnCode, emailData = self.IMAPClient.fetch(emailIdNum, openCode) 
         if (rtnCode != "OK"):
             print("Bad email return code received!!")
             

--- a/backend/src/emailing/emailAgent.py
+++ b/backend/src/emailing/emailAgent.py
@@ -1017,11 +1017,15 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
 
         # get terminal size to make message appear on one line (subtract to make comfortable)
         columns, rows = shutil.get_terminal_size(fallback=(80, 24))
-        spaceCushion = len(emailMsg["DateTime"]) + len(" - #) ") + len(unreadText) + 5 # last 5 comes from email id reaching up to 99999 (might need to make more)
+        # last 5 comes from email id reaching up to 99999 (might need to make more)
+        spaceCushion = len(emailMsg["DateTime"]) + len(" - #) ") + len(unreadText) + 5
+
+        # actually format the brief description string 
         descStr = ""
         if (emailMsg['Subject'].strip().isspace() or emailMsg['Subject'] == '' or emailMsg['Subject'] == None):
             # there is no subject, show part of message instead
-            descStr = "{0} - #{1}) {2}...{3}".format(emailMsg['DateTime'] , emailMsg['idNum'], emailMsg['Body'][:columns-spaceCushion], unreadText)
+            descStr = "{0} - #{1}) {2}...{3}".format(
+                emailMsg['DateTime'] , emailMsg['idNum'], emailMsg['Body'][:columns-spaceCushion], unreadText)
 
         # there is an actual subject in the message
         else:
@@ -1030,7 +1034,8 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
             if overflow < 0: 
                 emailMsg = emailMsg[:overflow]
                 moreToMsg = "..."
-            descStr = "{0} - #{1}) {2}{3}{4}".format(emailMsg['DateTime'], emailMsg['idNum'], emailMsg['Subject'], moreToMsg, unreadText)
+            descStr = "{0} - #{1}) {2}{3}{4}".format(
+                emailMsg['DateTime'],  emailMsg['idNum'], emailMsg['Subject'], moreToMsg, unreadText)
 
         return descStr
 

--- a/backend/src/emailing/emailAgent.py
+++ b/backend/src/emailing/emailAgent.py
@@ -93,7 +93,7 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
 
         # if running via CLI, access account meant for CLI user
         self._userId = self._cliUserId if self.isCommandLine else userId
-        if self.isCommandLine: self.configureUsername()
+        if self.isCommandLine: self.configureLogin()
 
         # Fetch the contact list from the database
         self.contactList = self.getContactList(self._userId)
@@ -105,7 +105,7 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
         # display contents of the existing contact list
         if displayContacts: self.printContactListPretty()
 
-    def configureUsername(self, overrideUsername:bool=False, overridePassword:bool=False):
+    def configureLogin(self, overrideUsername:bool=False, overridePassword:bool=False):
         """
             \n@Brief: Helper function that sets username & password if needed
             \n@Param: (optional - default = False) overrideUsername - Update the username?

--- a/backend/src/emailing/emailAgent.py
+++ b/backend/src/emailing/emailAgent.py
@@ -119,13 +119,13 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
 
         if needToSetUsername:
             while True:
-                newUsername = utils.promptUntilSuccess("Enter your display name when sending texts: ")
+                newUsername = utils.promptUntilSuccess("Enter your display name when sending texts (can be updated later): ")
                 if self.isUsernameInUse(newUsername): print(f"Username {newUsername} is already taken, choose another")
                 else: break
             self.setUsernameById(self._userId, newUsername)
 
         if needToSetPassword:
-            newPassword = utils.promptUntilSuccess("Enter your password (to login via the web GUI): ")
+            newPassword = utils.promptUntilSuccess("Enter your password (to login via the web GUI - can be updated later): ")
             self.setPasswordById(self._userId, newPassword)
 
         # Set variables needed for future

--- a/backend/src/emailing/emailAgent.py
+++ b/backend/src/emailing/emailAgent.py
@@ -986,18 +986,20 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
     ###########################################################################################################
     def markAsUnread(self, emailId:str):
         """
-            Mark an email (with 'emailId' in its original encoded form) as unread
+            Mark an email (based on its 'emailId') as unread
             WARNING: Only works if email is not ALREADY unread
         """
-        self.IMAPClient.store(emailId, "-FLAGS", "\SEEN")
+        self.IMAPClient.store(str(int(emailId)), "-FLAGS", "\SEEN")
 
     def markAsRead(self, emailId:str):
         """
-            Mark an email (with 'emailId' in its original encoded form) as read
+            Mark an email (based on its 'emailId') as read
             WARNING: Only works if email is not ALREADY read 
         """
-        print(f"marking {emailId} as read")
-        self.IMAPClient.store(str(emailId), "+FLAGS", "\SEEN")
+        # ... I hate that it took me > 1 hr to realize python was interpreting the type wrong
+        # have to be explicit and convert it to an int, and then convert to a string
+        self.IMAPClient.store(str(int(emailId)), "+FLAGS", "\SEEN")
+
     ###########################################################################################################
 
     def printEmailListPretty(self, emailList:list, lowerBound:int=0, upperBound:int=-1):

--- a/backend/src/emailing/emailAgent.py
+++ b/backend/src/emailing/emailAgent.py
@@ -93,6 +93,9 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
 
         # if running via CLI, access account meant for CLI user
         self._userId = self._cliUserId if self.isCommandLine else userId
+        self.configureUsername()
+
+        # Fetch the contact list from the database
         self.contactList = self.getContactList(self._userId)
 
         # work around for sending text messages with char limit (wait to add content)
@@ -101,6 +104,18 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
 
         # display contents of the existing contact list
         if displayContacts: self.printContactListPretty()
+
+    def configureUsername(self):
+        """Helper function that sets username if needed"""
+        myUsername = self.getUsernameById(self._userId)
+        needToSetUsername = myUsername == "" # will only be the case for command line
+        if needToSetUsername:
+            while True:
+                newUsername = utils.promptUntilSuccess("Enter your display name when sending texts: ")
+                if self.isUsernameInUse(newUsername): print(f"Username {newUsername} is already taken, choose another")
+                else: break
+            newPassword = utils.promptUntilSuccess("Enter your password (to login via the web GUI): ")
+            self._addUserToColl(self._userId, newUsername, newPassword, None)
 
     def sendMsg(self, receiverContactInfo, sendMethod:str='', msgToSend:str='')->str():
         """

--- a/backend/src/emailing/emailAgent.py
+++ b/backend/src/emailing/emailAgent.py
@@ -1038,7 +1038,7 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
         if self.isCommandLine: 
             self._stopOnKeypress(
                 fetchEmailsWorker,
-                prompt="stop fetching emails",
+                prompt="stop fetching emails (this may take awhile)",
                 toPrintOnStop="Stopped fetching",
             )
         else: fetchEmailsWorker()

--- a/backend/src/emailing/emailAgent.py
+++ b/backend/src/emailing/emailAgent.py
@@ -1125,17 +1125,18 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
                 return (printedStr, emailDict)
 
             # error checking for valid email id
-            while not idSelected in idDict.keys():
+            idListInt = utils.convertToIntList(idDict.keys())
+            while not idSelected in idListInt:
                 idSelected = input("Enter email id to open: ").replace('\n', '').strip()
                 if idSelected.isspace() or not idSelected.isdigit(): idSelected = -1
                 idSelected = int(idSelected)
 
         # open selected email
-        relevantInfo = idDict[idSelected]
+        relevantInfo = idDict[str(idSelected)]
         emailListIdx = relevantInfo["idx"]
         emailDict = emailList[emailListIdx]
         printedStr = self.processEmailDict(emailDict)
-        self.markAsRead(idSelected)
+        self.markAsRead(emailDict["idNum"])
         return (printedStr, emailDict)
 
     def _reply(self, startedBySendingEmail:bool, emailMsgDict:dict):

--- a/backend/src/emailing/emailAgent.py
+++ b/backend/src/emailing/emailAgent.py
@@ -1031,12 +1031,13 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
 
                 # exit for loop if fetched enough
                 if (maxFetchCount != -1 and numFetched >= maxFetchCount): return
+            return
 
         # if command line, do special trick to get user to stop the fetching
         if self.isCommandLine: self._stopOnKeypress(
             fetchEmailsWorker,
-            prompt="to stop fetching emails",
-            toPrintOnStop="Stopped fetching"
+            prompt="stop fetching emails",
+            toPrintOnStop="Stopped fetching",
         )
         else: fetchEmailsWorker()
 

--- a/backend/src/emailing/emailAgent.py
+++ b/backend/src/emailing/emailAgent.py
@@ -1034,11 +1034,12 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
             return
 
         # if command line, do special trick to get user to stop the fetching
-        if self.isCommandLine: self._stopOnKeypress(
-            fetchEmailsWorker,
-            prompt="stop fetching emails",
-            toPrintOnStop="Stopped fetching",
-        )
+        if self.isCommandLine: 
+            self._stopOnKeypress(
+                fetchEmailsWorker,
+                prompt="stop fetching emails",
+                toPrintOnStop="Stopped fetching",
+            )
         else: fetchEmailsWorker()
 
         return (emailList, idDict)

--- a/backend/src/emailing/emailAgent.py
+++ b/backend/src/emailing/emailAgent.py
@@ -59,7 +59,12 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
             \n@input: useDefault- True to use the default email account to send/receive texts & emails
             \n@Param: userId - (optional) The UUID belonging to the user for non-command line uses
         """
+        # this variable is neccesary for the webApp and anything that wants to 
+        # implement this class not using the command line
+        self.isCommandLine = isCommandLine
+
         # Inheret all functions and 'self' variables
+        DatabaseManager.__init__(self, printCollectionCreation=not self.isCommandLine)
         super().__init__()
 
         self.__pathToThisDir = os.path.dirname(os.path.abspath(__file__))
@@ -86,10 +91,6 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
         # boolean that when set to True means the program will login
         # to a known email account wihtout extra inputs needed
         self.useDefault = useDefault 
-
-        # this variable is neccesary for the webApp and anything that wants to 
-        # implement this class not using the command line
-        self.isCommandLine = isCommandLine
 
         # if running via CLI, access account meant for CLI user
         self._userId = self._cliUserId if self.isCommandLine else userId

--- a/backend/src/emailing/emailAgent.py
+++ b/backend/src/emailing/emailAgent.py
@@ -939,6 +939,10 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
         emailList = self.getEmailListWithContent(emailFilter=_unreadEmailFilter)
         return emailList
 
+    def markAsUnread(self, emailId):
+        """Mark an email (with 'emailId') as unread"""
+        self.IMAPClient.uid("STORE", emailId, "+FLAGS", "\SEEN")
+
     def printEmailListPretty(self, emailList:list, lowerBound:int=0, upperBound:int=-1):
         """
             \n@Brief- Takes email list and prints: "Mail Id #: <subject> "

--- a/backend/src/emailing/emailAgent.py
+++ b/backend/src/emailing/emailAgent.py
@@ -105,17 +105,30 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
         # display contents of the existing contact list
         if displayContacts: self.printContactListPretty()
 
-    def configureUsername(self):
-        """Helper function that sets username if needed"""
+    def configureUsername(self, overrideUsername:bool=False, overridePassword:bool=False):
+        """
+            \n@Brief: Helper function that sets username & password if needed
+            \n@Param: (optional - default = False) overrideUsername - Update the username?
+            \n@Param: (optional - default = False) overridePassword - Update the password?
+        """
+        # will only be the case for command line (myUsername == "" if first time doing command line)
         myUsername = self.getUsernameById(self._userId)
-        needToSetUsername = myUsername == "" # will only be the case for command line
+        myPassword = self.getPasswordFromId(self._userId)
+        needToSetUsername = overrideUsername or myUsername == ""
+        needToSetPassword = overridePassword or myPassword == ""
+
         if needToSetUsername:
             while True:
                 newUsername = utils.promptUntilSuccess("Enter your display name when sending texts: ")
                 if self.isUsernameInUse(newUsername): print(f"Username {newUsername} is already taken, choose another")
                 else: break
+            self.setUsernameById(self._userId, newUsername)
+
+        if needToSetPassword:
             newPassword = utils.promptUntilSuccess("Enter your password (to login via the web GUI): ")
-            self._addUserToColl(self._userId, newUsername, newPassword, None)
+            self.setPasswordById(self._userId, newPassword)
+
+        # Set variables needed for future
         self._sendTextBlurb = f"Dest: {myUsername}" # text to match on receive side
 
     def createTextReturnInstructions(self)->str():

--- a/backend/src/emailing/emailAgent.py
+++ b/backend/src/emailing/emailAgent.py
@@ -974,15 +974,23 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
         return emailList
 
     ############################# Mark as (un)read functions ###########################
-    # Note: +/-FLAGS either adds or removes flag
+    # Note: +/-FLAGS either adds or removes flag (Dont work due to "unexpected response")
     ####################################################################################
-    def markAsUnread(self, emailId):
-        """Mark an email (with 'emailId') as unread"""
-        self.IMAPClient.store(emailId, "-FLAGS", "\SEEN")
+    def markAsUnread(self, emailId:str):
+        """
+            Mark an email (with 'emailId' in its original encoded form) as unread
+            WARNING: Does not seem to work with gmail so use at your own risk
+        """
+        self.IMAPClient.store(str(emailId), "-FLAGS", "\SEEN")
 
-    def markAsRead(self, emailId):
-        """Mark an email (with 'emailId') as read"""
-        self.IMAPClient.store(emailId, "+FLAGS", "\SEEN")
+    def markAsRead(self, emailId:str):
+        """
+            Mark an email (with 'emailId' in its original encoded form) as read
+            WARNING: Does not seem to work with gmail so use at your own risk
+            Note: Due to necessity & the weirdness of gmail, necessary approach to marking as read will be to fetch
+        """
+        # self.IMAPClient.uid("STORE", str(emailId), "+FLAGS", "\SEEN") -- produces "UNEXPECTED RESPONSE" fatal error
+        self.fetchEmail(emailId, leaveUnread=False)
     ####################################################################################
 
     def printEmailListPretty(self, emailList:list, lowerBound:int=0, upperBound:int=-1):

--- a/backend/src/emailing/emailAgent.py
+++ b/backend/src/emailing/emailAgent.py
@@ -1316,7 +1316,9 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
                     continue
 
         # check if the email is relevant to the logged in user
+        # remove special footer if there
         belongsToUser = body.find(self._sendTextBlurb) != -1
+        if belongsToUser: body = body.replace(self._sendTextBlurb, "").strip()
 
         # Get date and time of email
         dataTuple = email.utils.parsedate_tz(emailMsg['Date'])
@@ -1358,7 +1360,8 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
             "Subject": "", 
             "Body": "",
             "idNum": "",
-            "unread": bool()
+            "unread": bool(),
+            "belongsToUser": bool()
         }
         if (emailDict.keys() != sampleDict.keys()):
             raise Exception("Incorrectly Passed Dictionary, needs this format: {0}".format(sampleDict))

--- a/backend/src/emailing/emailAgent.py
+++ b/backend/src/emailing/emailAgent.py
@@ -923,8 +923,7 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
             \n@Note: call 'processRawEmail(rawEmail, emailIdNum)' to convert to usable form
 
         """
-        if leaveUnread:     openCode = '(BODY.PEEK[])'
-        else:               openCode = '(RFC822)'
+        openCode = self.openUnread if leaveUnread else self.openMarkRead
         rtnCode, emailData = self.IMAPClient.fetch(emailIdNum, openCode) 
         if (rtnCode != "OK"):
             print("Bad email return code received!!")

--- a/backend/src/emailing/emailAgent.py
+++ b/backend/src/emailing/emailAgent.py
@@ -93,7 +93,7 @@ class EmailAgent(DatabaseManager, KeyboardMonitor):
 
         # if running via CLI, access account meant for CLI user
         self._userId = self._cliUserId if self.isCommandLine else userId
-        self.configureUsername()
+        if self.isCommandLine: self.configureUsername()
 
         # Fetch the contact list from the database
         self.contactList = self.getContactList(self._userId)

--- a/backend/src/emailing/emailCLIManager.py
+++ b/backend/src/emailing/emailCLIManager.py
@@ -121,6 +121,28 @@ class CLIManager(EmailAgent):
             help="The receipient's lastname",
         )
 
+        ##################################################################################################################
+        # Login Managers
+        ##################################################################################################################
+        loginManagersGroup = parser.add_argument_group(
+            title="Login",
+            description="Helps update login information",
+        )
+        loginManagersGroup.add_argument(
+            "-x", "--username",
+            action="store_true",
+            dest="setUsername",
+            required=False,
+            help="Set what username (display name) when sending text messages and exit",
+        )
+        loginManagersGroup.add_argument(
+            "-p", "--password",
+            action="store_true",
+            dest="setPassword",
+            required=False,
+            help="Set your password when logging in and exit",
+        )
+
         # Actually Parse Flags (turn into dictionary)
         args = vars(parser.parse_args()) # converts all '-' after '--' to '_' (--add-contact -> 'add_contact')
 
@@ -134,6 +156,10 @@ class CLIManager(EmailAgent):
         elif args["updateContact"]:
             super().__init__(displayContacts=True, isCommandLine=True)
             self.updateContactInfo()
+            sys.exit(0)
+        elif args["setUsername"] or args["setPassword"]:
+            super().__init__(displayContacts=False, isCommandLine=True)
+            self.configureUsername(overrideUsername=args["setUsername"], overridePassword=args["setPassword"])
             sys.exit(0)
 
         # Create a class obj for this file

--- a/backend/src/emailing/emailCLIManager.py
+++ b/backend/src/emailing/emailCLIManager.py
@@ -159,7 +159,7 @@ class CLIManager(EmailAgent):
             sys.exit(0)
         elif args["setUsername"] or args["setPassword"]:
             super().__init__(displayContacts=False, isCommandLine=True)
-            self.configureUsername(overrideUsername=args["setUsername"], overridePassword=args["setPassword"])
+            self.configureLogin(overrideUsername=args["setUsername"], overridePassword=args["setPassword"])
             sys.exit(0)
 
         # Create a class obj for this file

--- a/backend/src/emailing/keyboardHandler.py
+++ b/backend/src/emailing/keyboardHandler.py
@@ -109,16 +109,17 @@ class KeyboardMonitor():
         # remove extra newlines
         return msgToRtn.strip()
 
-    def _stopOnKeypress(self, workerFn, prompt:str="\b", toPrintOnStop:str=""):
+    def _stopOnKeypress(self, workerFn, prompt:str="\b", toPrintOnStop:str="", printPrompts:bool=True):
         """
             \n@Brief: Stops running 'workerFn()' when a certain key is pressed
             \n@Param: workerFn - The function that should be stopped on the keypress 
             (Needs threading.Event arg that will stop worker if event.isSet())
             \n@Param: toPrintOnStop - (optional) What's printed when the thread is stopped during target's execution
             \n@Param: prompt - The prompt to the user before they wait to stop about wait they are waiting for
+            \n@Param: printPrompts - Set to false to keep prints to a minimum
         """
         # hide terminal inputs (only care about 'escape')
-        print(f"Press escape ('esc') to {prompt}...")
+        if printPrompts: print(f"Press escape ('esc') to {prompt}...")
 
         # Create Event & EventThread to stop keyboard thread if worker finishes
         # If worker fn finishes first, will trigger a callback that presses the escape key to stop keyboard monitor
@@ -134,7 +135,7 @@ class KeyboardMonitor():
         funcToRunThread = threadWithException(
             name="stop-me-on-keypress-thread",
             target=workerFn,
-            toPrintOnStop=toPrintOnStop,
+            toPrintOnStop=toPrintOnStop if printPrompts == True else "",
             stopEvent=stopEvent
         )
 

--- a/backend/src/emailing/keyboardHandler.py
+++ b/backend/src/emailing/keyboardHandler.py
@@ -6,14 +6,14 @@
 #------------------------------STANDARD DEPENDENCIES-----------------------------#
 import os, sys
 import argparse # for CLI Flags
-from threading import Thread
+from threading import Thread, Event
 
 #-----------------------------3RD PARTY DEPENDENCIES-----------------------------#
 from pynput.keyboard import Key, KeyCode, Controller, Listener # to monitor keyboard
 
 #--------------------------------OUR DEPENDENCIES--------------------------------#
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
-from backend.src.threadHelper.killableThreads import threadWithException
+from backend.src.threadHelper.killableThreads import threadWithException, stopThreadOnSetCallback
 
 class KeyboardMonitor():
     def __init__(self, printKeyPresses=False):
@@ -47,7 +47,18 @@ class KeyboardMonitor():
 
         return __onRelease
 
-    def inputUntil(self, returnThread:bool=True, stopKey:str=None, suppressTerm:bool=False)->Listener():
+    def _pressEscape(self):
+        """Helper function to press the escape ('esc') key"""
+        keyboard = Controller()
+        # press & release escape
+        keyboard.press(Key.esc)
+        keyboard.release(Key.esc)
+
+    def inputUntil(self, 
+            returnThread:bool=True,
+            stopKey:str=None,
+            suppressTerm:bool=False,
+        )->Listener():
         """
             \n@Brief: Collects keypresses until 'stopKey' is pressed and released (defaults to 'escape' key)
             \n@Param: returnThread - If False, block until stop key. If True, return the thread to be handled locally
@@ -101,31 +112,51 @@ class KeyboardMonitor():
     def _stopOnKeypress(self, workerFn, prompt:str="\b", toPrintOnStop:str=""):
         """
             \n@Brief: Stops running 'workerFn()' when a certain key is pressed
-            \n@Param: workerFn - The function that should be stopped on the keypress
+            \n@Param: workerFn - The function that should be stopped on the keypress 
+            (Needs threading.Event arg that will stop worker if event.isSet())
             \n@Param: toPrintOnStop - (optional) What's printed when the thread is stopped during target's execution
             \n@Param: prompt - The prompt to the user before they wait to stop about wait they are waiting for
         """
         # hide terminal inputs (only care about 'escape')
         print(f"Press escape ('esc') to {prompt}...")
-        # Create threads to run
 
+        # Create Event & EventThread to stop keyboard thread if worker finishes
+        # If worker fn finishes first, will trigger a callback that presses the escape key to stop keyboard monitor
+        stopEvent = Event()
+        stopEventThread = stopThreadOnSetCallback(
+            name="stopEventThread",
+            onStopCallback=self._pressEscape,
+            stopEvent=stopEvent
+        )
+
+        # Create threads to run
         # worker that should be stopped when the key is pressed
         funcToRunThread = threadWithException(
             name="stop-me-on-keypress-thread",
             target=workerFn,
-            toPrintOnStop=toPrintOnStop
+            toPrintOnStop=toPrintOnStop,
+            stopEvent=stopEvent
         )
 
-        # on 'esc'
-        stopKeyThread = self.inputUntil(returnThread=True, suppressTerm=True, )
+        # on 'esc' (suppressTerm = False so user can still use keyboard -- just not in terminal)
+        stopKeyThread = self.inputUntil(returnThread=True, suppressTerm=False)
 
         # have the custom function run, but stop it when the stop key thread finishes
         # https://www.geeksforgeeks.org/python-different-ways-to-kill-a-thread/
-        stopKeyThread.start() # start monitor first (might be delay, so it should be available prior)
-        funcToRunThread.start() # start worker function
-        stopKeyThread.join() # block main thread until monitoring thread stop (i.e. 'esc' is clicked)
-        funcToRunThread.raise_exception() # ends the worker function by causing an exception
-        funcToRunThread.join() # kill the thread completely
+        # start monitor threads first (might be delay, so it should be available prior)
+        stopEventThread.start() # montiors keyboard
+        stopKeyThread.start() # checks if worker fn finishes first
+
+        # start worker function
+        funcToRunThread.start()
+
+        # block main thread until monitoring thread stop (i.e. 'esc' is clicked)
+        stopKeyThread.join()
+        
+        # ends the worker function by causing an exception
+        funcToRunThread.raise_exception()
+        # kill the thread completely
+        funcToRunThread.join()
 
 # Test functionality
 if __name__ == "__main__":

--- a/backend/src/threadHelper/killableThreads.py
+++ b/backend/src/threadHelper/killableThreads.py
@@ -4,12 +4,13 @@ from queue import Queue
 import ctypes
 
 class threadWithException(threading.Thread):
-    def __init__(self, name:str, target, toPrintOnStop:str=""):
+    def __init__(self, name:str, target, toPrintOnStop:str="", stopEvent:threading.Event=None):
         """
             \n@Brief: Helper class that makes it easy to stop a thread
             \n@Param: name - The name of the thread
             \n@Param: target - the function to perform that will be stopped in the middle
             \n@Param: toPrintOnStop - (optional) What's printed when the thread is stopped during target's execution
+            \n@Param: stopEvent - Event to broadcast a stop message if this worker thread finishes
             \n@Note: https://www.geeksforgeeks.org/python-different-ways-to-kill-a-thread/ -- "raising exceptions"
             \n@Use: Create it -> start it -> sleep/do other action -> thisThread.raise_exception() -> thisThread.join()
         """
@@ -17,11 +18,13 @@ class threadWithException(threading.Thread):
         self.name = name
         self.workerFn = target
         self.toPrintOnStop = toPrintOnStop
+        self.stopEvent = stopEvent
 
     def run(self): 
         # target function of the thread class 
         try:
             self.workerFn()
+            if self.stopEvent != None: self.stopEvent.set()
         finally:
             if self.toPrintOnStop != "": print(self.toPrintOnStop)
 
@@ -40,3 +43,25 @@ class threadWithException(threading.Thread):
         if res > 1: 
             ctypes.pythonapi.PyThreadState_SetAsyncExc(thread_id, 0)
             print('Exception raise failure')
+
+class stopThreadOnSetCallback(threading.Thread):
+    def __init__(self, name:str, onStopCallback, stopEvent:threading.Event=None, *args, **kwargs):
+        """
+            \n@Brief: Helper class that makes it easy to stop a thread when threading.Event.set() is doen
+            \n@Param: name - The name of the thread
+            \n@Param: onStopCallback - the function to perform when the thread is told to stop
+            \n@Param: stopEvent - Event to broadcast a stop message if this worker thread finishes
+            \n@Note: https://www.geeksforgeeks.org/python-different-ways-to-kill-a-thread/ -- "raising exceptions"
+            \n@Use: Create it -> start it -> sleep/do other action -> stopEvent.set() -> onStopCallback() -> exit
+        """
+        threading.Thread.__init__(self) 
+        self.name = name
+        self.onStopCallback = onStopCallback
+        self.stopEvent = stopEvent
+        self.args = args
+        self.kwargs = kwargs
+
+    def run(self): 
+        """Waits until stopEvent.set() is called and then triggers callback"""
+        self.stopEvent.wait()
+        self.onStopCallback(*self.args, **self.kwargs)

--- a/backend/src/utils.py
+++ b/backend/src/utils.py
@@ -85,3 +85,11 @@ def isList(objToTest):
 
 def isDict(objToTest):
     return type(objToTest) is dict
+
+def convertToIntList(listToConvert):
+    toInt = lambda x: int(x)
+    return list(map(toInt, listToConvert))
+
+def convertToStrList(listToConvert):
+    toStr  = lambda x: str(x)
+    return list(map(toStr, listToConvert))

--- a/backend/src/utils.py
+++ b/backend/src/utils.py
@@ -6,6 +6,7 @@ import platform
 import subprocess
 # used to get local network exposible IP
 import socket
+import copy
 
 def loadJson(pathToJson):
     """Wrapper function that makes it easy to load a json"""
@@ -23,7 +24,11 @@ def keyExists(thisDict, key):
     return key in thisDict
 
 def mergeDicts(dict1, dict2):
-    return {**dict1, **dict2}
+    # return {**dict1, **dict2} # doesnt always work
+    toRtn = copy.deepcopy(dict1)
+    for key in list(dict2.keys()):
+        toRtn[key] = dict2[key]
+    return toRtn
 
 def isWindows():
     myPlatform = platform.system()

--- a/backend/src/webApp/userManager.py
+++ b/backend/src/webApp/userManager.py
@@ -44,10 +44,7 @@ class UserManager(LoginManager, DatabaseManager):
                 \n@Param: userToken - The user's unique token id
                 \n@Return: Reference to the User class related to this uuid
             """
-            userMatch = self.findUserById(userToken)
-            # if User obj is not defined, create a new one
-            if userMatch == None: userMatch = User(userToken)
-            return userMatch 
+            return self.findUserById(userToken, User)
 
         @self.unauthorized_handler
         def onNeedToLogIn():

--- a/backend/src/webApp/userManager.py
+++ b/backend/src/webApp/userManager.py
@@ -44,7 +44,10 @@ class UserManager(LoginManager, DatabaseManager):
                 \n@Param: userToken - The user's unique token id
                 \n@Return: Reference to the User class related to this uuid
             """
-            return self.findUserById(userToken) 
+            userMatch = self.findUserById(userToken)
+            # if User obj is not defined, create a new one
+            if userMatch == None: userMatch = User(userToken)
+            return userMatch 
 
         @self.unauthorized_handler
         def onNeedToLogIn():

--- a/backend/src/webApp/webApp.py
+++ b/backend/src/webApp/webApp.py
@@ -250,7 +250,6 @@ class WebApp(UserManager):
                 elif (proccessData['task'] == "receiving"):
                     # responsible for login to get preliminary email data
                     # use ui dropdown to select which email to fully fetch
-                    print("receiving")
                     numToFetch = current_user.getNumFetch()
                     preliminaryEmailData = current_user.userReceiveEmailUser(numToFetch)
                     optDataDict = utils.mergeDicts(optDataDict, preliminaryEmailData)

--- a/backend/src/webApp/webApp.py
+++ b/backend/src/webApp/webApp.py
@@ -162,7 +162,7 @@ class WebApp(UserManager):
                 # check results
                 isSuccess = validUsername and validPassword # only both true == success
                 if isSuccess:
-                    user = self.getUserByUsername(username)
+                    user = self.getUserByUsername(username, User)
                     login_user(user, remember=form.rememberMe.data)
 
                     # route to original destination


### PR DESCRIPTION
- closes #41

- make send/received texts private:
    - all texts now get send with a quick blurb saying to add a certain string (the username) to their texts or else the person will not get their response
    - on the receive side, only texts containing this special blurb are shown to the user
    - unless someone directly logs into the email account (which I will be patching soon) you cannot access someone else's data

- side note, due to need, I added a bunch of really cool keyboard monitoring python library and create some really useful threading helpers
